### PR TITLE
* Fixed subtotal empty value

### DIFF
--- a/app/code/local/PayU/Account/Model/Payment.php
+++ b/app/code/local/PayU/Account/Model/Payment.php
@@ -252,7 +252,7 @@ class PayU_Account_Model_Payment extends Mage_Payment_Model_Method_Abstract
 
         // assigning the shopping cart
         $shoppingCart = array(
-            'GrandTotal' => $this->toAmount(Mage::getSingleton('checkout/cart')->getQuote()->getSubtotal()),
+            'GrandTotal' => $this->toAmount($this->_order->getSubtotal()),
             'CurrencyCode' => $orderCurrencyCode,
             'ShoppingCartItems' => $items
         );


### PR DESCRIPTION
Subtotal value passed to PayU was always 0. Mage::getSingleton('checkout/cart') didn't seem to return current cart state. Using $this->_order instead.
Tested on Magento 1.7.0.2
