### PR TITLE
Shipping Non-sense

### DIFF
--- a/app/code/community/PayU/Account/Model/Payment.php
+++ b/app/code/community/PayU/Account/Model/Payment.php
@@ -136,34 +136,14 @@ class PayU_Account_Model_Payment extends Mage_Payment_Model_Method_Abstract
 
         $orderType = ($this->_order->getIsVirtual ()) ? "VIRTUAL" : "MATERIAL";
         
-        if (empty ( $allShippingRates )) {
+		  if($order->getShippingInclTax() > 0) {
+				$shippingCostList ['shippingMethods'] [] = array(
+					'name' => $order->getShippingDescription(),
+					'country' => $orderCountryCode,
+					'price' => $this->toAmount($order->getShippingInclTax()),
+				);
+		  }
 
-            $allShippingRates = Mage::getStoreConfig ( 'carriers', Mage::app ()->getStore ()->getId () );
-            
-            $methodArr = explode ( "_", $this->_order->getShippingMethod () );
-            
-            foreach ( $allShippingRates as $key => $rate ) {
-                if ($rate ['active'] == 1 && $rate ['showmethod'] == 1 && isset ( $rate ['price'] ) /* && $methodArr [0] == $key */) {
-                    $shippingCostList ['shippingMethods'] [] = array (
-                            'name' => $rate ['title'] . " " . $rate ['name'],'country' => $rate ['specificcountry'],'price' => $this->toAmount ( $rate ['price'] ) 
-                    );
-                }
-            
-            }
-            
-        
-        } else {
-            foreach ( $allShippingRates as $rate ) {
-                $gross = $this->toAmount ( $rate->getPrice () );
-                
-                $shippingCostList ['shippingMethods'] [] = array (
-                        'name' => $rate->getMethodTitle (),'country' => $orderCountryCode,'price' => $gross 
-                );
-            
-            }
-            
-        }
-        
         $grandTotal = $this->_order->getGrandTotal () - $this->_order->getShippingAmount () - $order->getShippingTaxAmount();
         
         $shippingCost = array (


### PR DESCRIPTION
Resolving PayU API flaw resulting in IGNORING CUSTOMER DECISION on
shipping method as well as ignoring all in Magento constrains on
shipping methods.

This change is removing non-sense situation in whitch customer is asked
to select shipping method again after beeing redirected to PayU.
Moreover list of available shipping methods contains all active methods
for current shipping addres ignoring Magento mechanizms that allow You
to constrain shipping methods and control shiping method costs.

With this update API design flaw of not beeing able to send customer
selected shipping method is omitted by sending customer selected option
as only option. Beacuse of that customers does not have to reconsider
his decision and cannot abuse API design flaw by selecting cheaper
method that would not be available in Magento beacuse of applied
conditions.
