### PR TITLE
customerIp use first clientIp

### DIFF
--- a/app/code/community/PayU/Account/Model/Payment.php
+++ b/app/code/community/PayU/Account/Model/Payment.php
@@ -198,12 +198,18 @@ class PayU_Account_Model_Payment extends Mage_Payment_Model_Method_Abstract
             );
         }
 
+        $clientIp = Mage::app()->getFrontController()->getRequest()->getClientIp();
+
+        if($clientIp) {
+            $clientIp = trim(array_shift(explode(',', $clientIp, 2)));
+        }
+
         $OCReq = array(
             'merchantPosId' => OpenPayU_Configuration::getMerchantPosId(),
             'orderUrl' => Mage::getUrl('sales/order/view', array('order_id' => $order->getId())),
             'description' => $this->_helper()->__('Order #%s', $order->getId()),
             'products' => $items,
-            'customerIp' => Mage::app()->getFrontController()->getRequest()->getClientIp(),
+            'customerIp' => $clientIp,
             'notifyUrl' => $this->getConfig()->getUrl('orderNotifyRequest'),
             'continueUrl' => $this->getConfig()->getUrl('continuePayment'),
             'currencyCode' => $order->getOrderCurrencyCode(),


### PR DESCRIPTION
fix Error 8011 INVALID_CUSTOMER_IP, use first IP reported

Magento returns X-Forwarded-For request header if available.
It might contain multiple IPs.
